### PR TITLE
Add X-Xhprof-Enabled header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ To get started, install the package via composer:
 ```bash
 composer require --dev maantje/xhprof-buggregator-laravel
 ```
+
 ## Usage
 
 Set the buggregator endpoint in your environment file:
@@ -22,6 +23,13 @@ Enable Xhprof in your environment file when needed, but remember to disable it w
 ```env
 XHPROF_ENABLED=true
 ```
+
+Alternatively, you can include the `X-Xhprof-Enabled` header in your request to explicitly enable or disable profiling for that specific call. When this header is present, it takes precedence over the environment variable.
+
+Enabled values: `true` `1` `on` `yes`  
+Disabled values: `false` `0` `off` `no`
+
+This feature works great with a browser extension like [ModHeader](https://addons.mozilla.org/en-US/firefox/addon/modheader-firefox/). It lets you switch profiling on and off right from your browser.
 
 ## License
 

--- a/src/XhprofServiceProvider.php
+++ b/src/XhprofServiceProvider.php
@@ -16,7 +16,7 @@ class XhprofServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/xhprof.php', 'xhprof');
 
-        if (! config('xhprof.enabled')) {
+        if (! $this->isEnabled()) {
             return;
         }
 
@@ -61,5 +61,17 @@ class XhprofServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config/xhprof.php' => config_path('xhprof.php'),
         ]);
+    }
+
+    /**
+     * Checks if the profiler should be enabled
+     */
+    private function isEnabled(): bool
+    {
+        if (request()->hasHeader(XhprofProfiler::HEADER)) {
+            return filter_var(request()->header(XhprofProfiler::HEADER), FILTER_VALIDATE_BOOLEAN);
+        }
+
+        return config()->get('xhprof.enabled');
     }
 }

--- a/src/middleware/XhprofProfiler.php
+++ b/src/middleware/XhprofProfiler.php
@@ -9,6 +9,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class XhprofProfiler
 {
+    public const HEADER = 'X-Xhprof-Enabled';
+
     public function __construct(private readonly Profiler $profiler)
     {
         //

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,20 @@
 <?php
 
+use Illuminate\Http\Request;
 use Maantje\XhprofBuggregatorLaravel\Tests\TestCase;
+use Symfony\Component\HttpFoundation\HeaderBag;
 
 uses(TestCase::class)->in(__DIR__);
+
+function setXhprofEnabledHeader(string $value): void
+{
+    $request = Request::create('/path');
+
+    $request->headers = new HeaderBag([
+        'X-Xhprof-Enabled' => $value,
+    ]);
+
+    app()->bind('request', function () use ($request) {
+        return $request;
+    });
+}

--- a/tests/ProviderTest.php
+++ b/tests/ProviderTest.php
@@ -9,6 +9,21 @@ describe('enabled', function () {
         config()->set('xhprof.enabled', true);
     });
 
+    it('does not register middleware when header is given', function () {
+        setXhprofEnabledHeader('false');
+
+        $provider = new XhprofServiceProvider(app());
+
+        $provider->register();
+
+        /** @var \Illuminate\Foundation\Http\Kernel $kernel */
+        $kernel = app(Kernel::class);
+
+        expect(
+            $kernel->hasMiddleware(XhprofProfiler::class)
+        )->toBeFalse();
+    });
+
     it('registers middleware', function () {
         $provider = new XhprofServiceProvider(app());
 
@@ -26,6 +41,21 @@ describe('enabled', function () {
 describe('disabled', function () {
     beforeEach(function () {
         config()->set('xhprof.enabled', false);
+    });
+
+    it('registers middleware when header is given', function () {
+        setXhprofEnabledHeader('true');
+
+        $provider = new XhprofServiceProvider(app());
+
+        $provider->register();
+
+        /** @var \Illuminate\Foundation\Http\Kernel $kernel */
+        $kernel = app(Kernel::class);
+
+        expect(
+            $kernel->hasMiddleware(XhprofProfiler::class)
+        )->toBeTrue();
     });
 
     it('does not register middleware', function () {


### PR DESCRIPTION
Add support for X-Xhprof-Enabled header.

Allows to enable/disable the profiler only for certain requests.