### PR TITLE
Switch out NativeHttpClient for CurlHttpClient #16.

### DIFF
--- a/src/XhprofServiceProvider.php
+++ b/src/XhprofServiceProvider.php
@@ -8,7 +8,7 @@ use Maantje\XhprofBuggregatorLaravel\middleware\XhprofProfiler;
 use SpiralPackages\Profiler\DriverFactory;
 use SpiralPackages\Profiler\Profiler;
 use SpiralPackages\Profiler\Storage\WebStorage;
-use Symfony\Component\HttpClient\NativeHttpClient;
+use Symfony\Component\HttpClient\CurlHttpClient;
 use Throwable;
 
 class XhprofServiceProvider extends ServiceProvider
@@ -25,7 +25,7 @@ class XhprofServiceProvider extends ServiceProvider
 
         $this->app->bind(Profiler::class, function () {
             $storage = new WebStorage(
-                new NativeHttpClient(),
+                new CurlHttpClient(),
                 config('xhprof.endpoint'),
             );
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,4 @@ namespace Maantje\XhprofBuggregatorLaravel\Tests;
 
 use Orchestra\Testbench\TestCase as Orchestra;
 
-class TestCase extends Orchestra
-{
-}
+class TestCase extends Orchestra {}


### PR DESCRIPTION
This pull request resolves the issue where profiling doesn't work if the allow_url_fopen setting is disabled in PHP.
  
[Issue #16](https://github.com/maantje/xhprof-buggregator-laravel/issues/16).