### PR TITLE
docs: make sure xhprof is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Welcome to the Xhprof integration package for [buggregator](https://buggregator.dev/) in Laravel. This repository allows you to effortlessly enable Xhprof support for buggregator in your Laravel application.
 
+## Requirements
+
+Make sure that your server is configured with following PHP version and extensions:
+
+- PHP 8.1+
+- [XHProf](http://pecl.php.net/package/xhprof) ext or its fork [longxinH/xhprof](https://github.com/longxinH/xhprof).
+
 ## Installation
 
 To get started, install the package via composer:


### PR DESCRIPTION
Since this package uses the [Spiral profiler](https://github.com/spiral-packages/profiler) package this package might specify the same requirements.

It might be obvious that you need Xhprof before this package can run, however, by just installing the package without the extension you just get an error:

```
Undefined constant "SpiralPackages\Profiler\Driver\XHPROF_FLAGS_MEMORY"
``` 

I've also decided not to link to Uprofiler or Tideways as these are both archived.