### PR TITLE
Added support call Profiler from Container DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,47 @@ Disabled values: `false` `0` `off` `no`
 
 This feature works great with a browser extension like [ModHeader](https://modheader.com/). It lets you switch profiling on and off right from your browser.
 
-## Usage with Sail
+### Usage Profiler
+
+By default, the profiler is turned on and off with each HTTP request. 
+However, you may have other points where your\application starts. For example, it can be queues, commands, and so on.
+
+In such cases, you can configure the profiler to run in the desired location yourself:
+
+```php
+
+use SpiralPackages\Profiler\Profiler;
+
+class RegisterUserActionJob 
+{
+    public function __construct(
+        public string $name,
+        public string $password
+    ) {
+    }
+    
+    /**
+     * Get Profiler object from Container DI
+     * 
+     * @param Profiler $profiler
+     * @return void
+     */
+    public function handle(Profiler $profiler): void
+    {
+        try {
+            $profiler->start();
+            
+            // code for register new user
+        }
+        finally {
+            $profiler->end();
+        }
+    }
+}
+
+```
+
+### Usage with Sail
 
 Add the buggregator service to your docker-compose file:
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "require-dev": {
         "laravel/pint": "^1.0",
         "orchestra/testbench": "^8.8|^9.0",
+        "larastan/larastan": "^2.9",
         "pestphp/pest": "^2.20"
     },
     "autoload": {

--- a/src/Factories/OptionalProfilerFactory.php
+++ b/src/Factories/OptionalProfilerFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Maantje\XhprofBuggregatorLaravel\Factories;
+
+use Illuminate\Foundation\Application;
+use Maantje\XhprofBuggregatorLaravel\Middleware\XhprofProfiler;
+use SpiralPackages\Profiler\Driver\NullDriver;
+use SpiralPackages\Profiler\Profiler;
+use SpiralPackages\Profiler\Storage\NullStorage;
+
+final class OptionalProfilerFactory
+{
+    protected ProfilerFactory $profilerFactory;
+
+    public function __construct(
+        protected Application $app
+    ) {
+        $this->profilerFactory = new ProfilerFactory($this->app['config']);
+    }
+
+    public function create(): Profiler
+    {
+        if ($this->isEnabled()) {
+            return $this->profilerFactory->create();
+        }
+
+        return new Profiler(
+            storage: new NullStorage,
+            driver: new NullDriver,
+            appName: $this->app['config']->get('app.name'),
+        );
+    }
+
+    private function isEnabled(): bool
+    {
+        if ($this->app['request']->hasHeader(XhprofProfiler::HEADER)) {
+            return filter_var($this->app['request']->header(XhprofProfiler::HEADER), FILTER_VALIDATE_BOOLEAN);
+        }
+
+        return $this->app['config']->get('xhprof.enabled');
+    }
+}

--- a/src/Factories/ProfilerFactory.php
+++ b/src/Factories/ProfilerFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Maantje\XhprofBuggregatorLaravel\Factories;
+
+use Illuminate\Config\Repository;
+use SpiralPackages\Profiler\DriverFactory;
+use SpiralPackages\Profiler\Profiler;
+use SpiralPackages\Profiler\Storage\StorageInterface;
+use SpiralPackages\Profiler\Storage\WebStorage;
+use Symfony\Component\HttpClient\CurlHttpClient;
+
+final class ProfilerFactory
+{
+    public function __construct(
+        protected Repository $configRepository
+    ) {}
+
+    public function create(): Profiler
+    {
+        return new Profiler(
+            $this->makeStorage(),
+            DriverFactory::createXhrofDriver(),
+            $this->configRepository->get('app.name')
+        );
+    }
+
+    private function makeStorage(): StorageInterface
+    {
+        return new WebStorage(
+            new CurlHttpClient,
+            $this->configRepository->get('xhprof.endpoint'),
+        );
+    }
+}

--- a/src/Middleware/XhprofProfiler.php
+++ b/src/Middleware/XhprofProfiler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Maantje\XhprofBuggregatorLaravel\middleware;
+namespace Maantje\XhprofBuggregatorLaravel\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
@@ -11,10 +11,9 @@ class XhprofProfiler
 {
     public const HEADER = 'X-Xhprof-Enabled';
 
-    public function __construct(private readonly Profiler $profiler)
-    {
-        //
-    }
+    public function __construct(
+        private readonly Profiler $profiler
+    ) {}
 
     /**
      * Handle an incoming request.

--- a/tests/ProviderTest.php
+++ b/tests/ProviderTest.php
@@ -1,73 +1,99 @@
 <?php
 
 use Illuminate\Contracts\Http\Kernel;
-use Maantje\XhprofBuggregatorLaravel\middleware\XhprofProfiler;
+use Maantje\XhprofBuggregatorLaravel\Middleware\XhprofProfiler;
 use Maantje\XhprofBuggregatorLaravel\XhprofServiceProvider;
+use SpiralPackages\Profiler\Driver\NullDriver;
+use SpiralPackages\Profiler\Driver\XhprofDriver;
+use SpiralPackages\Profiler\Profiler;
+use SpiralPackages\Profiler\Storage\NullStorage;
+use SpiralPackages\Profiler\Storage\WebStorage;
 
-describe('enabled', function () {
+describe('xhprof enabled', function () {
     beforeEach(function () {
         config()->set('xhprof.enabled', true);
     });
 
-    it('does not register middleware when header is given', function () {
+    it('always registers middleware', function (?string $enabledFromHeader) {
+        if (! is_null($enabledFromHeader)) {
+            setXhprofEnabledHeader($enabledFromHeader);
+        }
+
+        $provider = new XhprofServiceProvider(app());
+
+        $provider->register();
+
+        /** @var \Illuminate\Foundation\Http\Kernel $kernel */
+        $kernel = app(Kernel::class);
+
+        expect(
+            $kernel->hasMiddleware(XhprofProfiler::class)
+        )->toBeTrue();
+    })->with([null, 'true', 'false']);
+
+    it('get profiler with storage and xhprof driver', function () {
+        $provider = new XhprofServiceProvider(app());
+
+        $provider->register();
+
+        /** @var Profiler $profiler */
+        $profiler = app(Profiler::class);
+
+        expect((fn () => $this->storage)->call($profiler))
+            ->toBeInstanceOf(WebStorage::class)
+            ->and((fn () => $this->driver)->call($profiler))
+            ->toBeInstanceOf(XhprofDriver::class);
+    });
+
+    it('get profiler nullable with storage and xhprof driver when header is given', function () {
         setXhprofEnabledHeader('false');
 
         $provider = new XhprofServiceProvider(app());
 
         $provider->register();
 
-        /** @var \Illuminate\Foundation\Http\Kernel $kernel */
-        $kernel = app(Kernel::class);
+        /** @var Profiler $profiler */
+        $profiler = app(Profiler::class);
 
-        expect(
-            $kernel->hasMiddleware(XhprofProfiler::class)
-        )->toBeFalse();
-    });
-
-    it('registers middleware', function () {
-        $provider = new XhprofServiceProvider(app());
-
-        $provider->register();
-
-        /** @var \Illuminate\Foundation\Http\Kernel $kernel */
-        $kernel = app(Kernel::class);
-
-        expect(
-            $kernel->hasMiddleware(XhprofProfiler::class)
-        )->toBeTrue();
+        expect((fn () => $this->storage)->call($profiler))
+            ->toBeInstanceOf(NullStorage::class)
+            ->and((fn () => $this->driver)->call($profiler))
+            ->toBeInstanceOf(NullDriver::class);
     });
 });
 
-describe('disabled', function () {
+describe('xhprof disabled', function () {
     beforeEach(function () {
         config()->set('xhprof.enabled', false);
     });
 
-    it('registers middleware when header is given', function () {
+    it('get profiler nullable with storage and xhprof driver', function () {
+        $provider = new XhprofServiceProvider(app());
+
+        $provider->register();
+
+        /** @var Profiler $profiler */
+        $profiler = app(Profiler::class);
+
+        expect((fn () => $this->storage)->call($profiler))
+            ->toBeInstanceOf(NullStorage::class)
+            ->and((fn () => $this->driver)->call($profiler))
+            ->toBeInstanceOf(NullDriver::class);
+    });
+
+    it('get profiler with storage and xhprof driver when header is given', function () {
         setXhprofEnabledHeader('true');
 
         $provider = new XhprofServiceProvider(app());
 
         $provider->register();
 
-        /** @var \Illuminate\Foundation\Http\Kernel $kernel */
-        $kernel = app(Kernel::class);
+        /** @var Profiler $profiler */
+        $profiler = app(Profiler::class);
 
-        expect(
-            $kernel->hasMiddleware(XhprofProfiler::class)
-        )->toBeTrue();
-    });
-
-    it('does not register middleware', function () {
-        $provider = new XhprofServiceProvider(app());
-
-        $provider->register();
-
-        /** @var \Illuminate\Foundation\Http\Kernel $kernel */
-        $kernel = app(Kernel::class);
-
-        expect(
-            $kernel->hasMiddleware(XhprofProfiler::class)
-        )->toBeFalse();
+        expect((fn () => $this->storage)->call($profiler))
+            ->toBeInstanceOf(WebStorage::class)
+            ->and((fn () => $this->driver)->call($profiler))
+            ->toBeInstanceOf(XhprofDriver::class);
     });
 });


### PR DESCRIPTION
Problem:

Profiling is only available for HTTP requests. To run the profiler in other locations, you must manually check the IsEnabled parameter.